### PR TITLE
Hotfix/Corrected dict property name

### DIFF
--- a/app/repositories/report_manager.py
+++ b/app/repositories/report_manager.py
@@ -41,7 +41,7 @@ class BaseReportManager:
                                                'count')
                                            ).group_by(cls.order_model.client_dni).order_by(desc('count')).limit(3).all()
 
-        return [{'posicion': pos + 1, 'name': customer.client_name, 'dni': customer.client_dni}
+        return [{'position': pos + 1, 'name': customer.client_name, 'dni': customer.client_dni}
                 for pos, customer in enumerate(loyal_customer)]
 
 


### PR DESCRIPTION
Due to an error, the dictionary's property name was written in Spanish clashing with the correct rules that we need to follow to develop.